### PR TITLE
Fix line length linting error

### DIFF
--- a/main_functions/Fukushima_sum2mat.R
+++ b/main_functions/Fukushima_sum2mat.R
@@ -78,7 +78,9 @@
 # sum2mat -----------------------------------------------------------------
 sum2mat <- function(expr_str, deparse_result = FALSE, print=1 ){
   
-  expr_str <- expr_str |> str_replace_all("\\{", "chu_kakko\\(") |> str_replace_all("\\}", "\\)")
+  expr_str <- expr_str |> 
+    str_replace_all("\\{", "chu_kakko\\(") |> 
+    str_replace_all("\\}", "\\)")
   expr <- tryCatch(parse(text = expr_str)[[1]], error = function(e) {
     warning("入力が有効な R 式ではありません")
     return(NULL)


### PR DESCRIPTION
Split a long line in `Fukushima_sum2mat.R` to adhere to the 80-character line limit.

---
<a href="https://cursor.com/background-agent?bcId=bc-27634678-6a0a-4cb7-b9bc-7f6bbd819bc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27634678-6a0a-4cb7-b9bc-7f6bbd819bc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

